### PR TITLE
cftime 1.5.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - pip
     - cython
     - numpy
+    - setuptools >=41.2
+    - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -39,6 +41,7 @@ test:
 about:
   home: https://github.com/Unidata/cftime
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Time-handling functionality from netcdf4-python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.5.0" %}
+{% set version = "1.5.1.1" %}
 
 package:
   name: cftime
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cftime/cftime-{{ version }}.tar.gz
-  sha256: b644bcb53346b6f4fe2fcc9f3b574740a2097637492dcca29632c817e0604f29
+  sha256: 6dc4d76ec7fe5a2d3c00dbe6604c757f1319613b75ef157554ef3648bf102a50
 
 build:
   number: 0


### PR DESCRIPTION
Update cftime to 1.5.1.1

Version change: bump version number from 1.5.0 to 1.5.1.1
Bug Tracker: new open issues https://github.com/Unidata/cftime/issues
Github releases:  https://github.com/Unidata/cftime/releases
Upstream license:  License file:  https://github.com/Unidata/cftime/blob/master/LICENSE
Upstream Changelog: https://github.com/Unidata/cftime/blob/master/Changelog
Upstream setup.py:  https://github.com/Unidata/cftime/blob/v1.5.1rel/setup.py
Upstream pyproject.toml:  https://github.com/Unidata/cftime/blob/v1.5.1rel/pyproject.toml

The package cftime is mentioned inside the packages:
netcdf4 |

Actions:
1. Add missing packages
2. Add license_family

Result:
- all-succeeded